### PR TITLE
Migrate to the latest wgpu trunk

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ bytemuck_derive = "1.8.0"
 flume = "0.11.1"
 glam = { version = "0.29.2", features = ["bytemuck"] }
 tokio = {version ="1.41.1",  features = ["full"]}
-wgpu = { git = "https://github.com/gfx-rs/wgpu", branch = "trunk" }
+wgpu = { git = "https://github.com/gfx-rs/wgpu", rev = "440b33f" }
 
 [dev-dependencies]
 rerun = "0.22.0"

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,178 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+   

--- a/examples/multi_sensor.rs
+++ b/examples/multi_sensor.rs
@@ -135,8 +135,8 @@ async fn main() {
                 required_features,
                 required_limits: wgpu::Limits::downlevel_defaults(),
                 memory_hints: wgpu::MemoryHints::MemoryUsage,
-            },
-            None,
+                trace: wgpu::Trace::Off
+            }
         )
         .await
     else {

--- a/examples/multi_sensor.rs
+++ b/examples/multi_sensor.rs
@@ -16,7 +16,9 @@ async fn main() {
     let instance = wgpu::Instance::default();
     let (adapter, device, queue) = get_raytracing_gpu(&instance).await;
 
-    let rec = rerun::RecordingStreamBuilder::new("rerun_example_app").spawn().unwrap();
+    let rec = rerun::RecordingStreamBuilder::new("rerun_example_app")
+        .spawn()
+        .unwrap();
 
     // Lets add a cube as an asset
     let cube = create_cube(1.0);

--- a/src/depth_camera/mod.rs
+++ b/src/depth_camera/mod.rs
@@ -115,7 +115,7 @@ impl DepthCamera {
                 wgpu::BindGroupEntry {
                     binding: 1,
                     resource: wgpu::BindingResource::AccelerationStructure(
-                        &scene.tlas_package.tlas(),
+                        &scene.tlas_package,
                     ),
                 },
                 wgpu::BindGroupEntry {
@@ -202,7 +202,7 @@ impl DepthCamera {
                 wgpu::BindGroupEntry {
                     binding: 1,
                     resource: wgpu::BindingResource::AccelerationStructure(
-                        &scene.tlas_package.tlas(),
+                        &scene.tlas_package,
                     ),
                 },
                 wgpu::BindGroupEntry {

--- a/src/depth_camera/mod.rs
+++ b/src/depth_camera/mod.rs
@@ -153,7 +153,7 @@ impl DepthCamera {
         let (sender, receiver) = flume::bounded(1);
         buffer_slice.map_async(wgpu::MapMode::Read, move |v| sender.send(v).unwrap());
 
-        device.poll(wgpu::Maintain::wait()).panic_on_timeout();
+        device.poll(wgpu::PollType::wait()).unwrap();
 
         receiver.recv().unwrap().unwrap();
 
@@ -240,7 +240,7 @@ impl DepthCamera {
         let (sender, receiver) = flume::bounded(1);
         buffer_slice.map_async(wgpu::MapMode::Read, move |v| sender.send(v).unwrap());
 
-        device.poll(wgpu::Maintain::wait()).panic_on_timeout();
+        device.poll(wgpu::PollType::wait()).unwrap();
 
         receiver.recv().unwrap().unwrap();
 

--- a/src/depth_camera/mod.rs
+++ b/src/depth_camera/mod.rs
@@ -120,9 +120,7 @@ impl DepthCamera {
                 },
                 wgpu::BindGroupEntry {
                     binding: 1,
-                    resource: wgpu::BindingResource::AccelerationStructure(
-                        &scene.tlas_package,
-                    ),
+                    resource: wgpu::BindingResource::AccelerationStructure(&scene.tlas_package),
                 },
                 wgpu::BindGroupEntry {
                     binding: 2,
@@ -207,9 +205,7 @@ impl DepthCamera {
                 },
                 wgpu::BindGroupEntry {
                     binding: 1,
-                    resource: wgpu::BindingResource::AccelerationStructure(
-                        &scene.tlas_package,
-                    ),
+                    resource: wgpu::BindingResource::AccelerationStructure(&scene.tlas_package),
                 },
                 wgpu::BindGroupEntry {
                     binding: 2,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -97,7 +97,7 @@ pub struct RayTraceScene {
     pub(crate) blas: Vec<wgpu::Blas>,
     pub(crate) tlas_package: wgpu::Tlas,
     pub(crate) assets: Vec<AssetMesh>,
-    pub(crate) instances: Vec<Instance>
+    pub(crate) instances: Vec<Instance>,
 }
 
 impl RayTraceScene {
@@ -108,7 +108,6 @@ impl RayTraceScene {
         assets: &Vec<AssetMesh>,
         instances: &Vec<Instance>,
     ) -> Self {
-
         let mut vertex_data = vec![];
         let mut index_data = vec![];
         let mut start_vertex_address = vec![];
@@ -145,8 +144,7 @@ impl RayTraceScene {
                 asset.vertex_buf.len(),
                 asset.index_buf.len()
             );
-            let geom_list = vec!
-            [wgpu::BlasTriangleGeometrySizeDescriptor {
+            let geom_list = vec![wgpu::BlasTriangleGeometrySizeDescriptor {
                 vertex_count: asset.vertex_buf.len() as u32,
                 vertex_format: wgpu::VertexFormat::Float32x3,
                 index_count: Some(asset.index_buf.len() as u32),
@@ -190,8 +188,7 @@ impl RayTraceScene {
         let blas_iter: Vec<_> = blas
             .iter()
             .enumerate()
-            .map(|(index, blas)| 
-            wgpu::BlasBuildEntry {
+            .map(|(index, blas)| wgpu::BlasBuildEntry {
                 blas,
                 geometry: wgpu::BlasGeometries::TriangleGeometries(vec![
                     wgpu::BlasTriangleGeometry {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,6 +3,9 @@ use std::{collections::HashMap, iter};
 use bytemuck_derive::{Pod, Zeroable};
 use glam::Affine3A;
 use wgpu::util::DeviceExt;
+
+pub use wgpu;
+
 pub mod depth_camera;
 pub mod lidar;
 pub mod utils;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -93,7 +93,7 @@ pub struct RayTraceScene {
     pub(crate) vertex_buf: wgpu::Buffer,
     pub(crate) index_buf: wgpu::Buffer,
     pub(crate) blas: Vec<wgpu::Blas>,
-    pub(crate) tlas_package: wgpu::TlasPackage,
+    pub(crate) tlas_package: wgpu::Tlas,
 }
 
 impl RayTraceScene {
@@ -181,7 +181,7 @@ impl RayTraceScene {
             max_instances: instances.len() as u32,
         });
 
-        let mut tlas_package = wgpu::TlasPackage::new(tlas);
+        let mut tlas_package = tlas;
 
         for (idx, instance) in instances.iter().enumerate() {
             tlas_package[idx] = Some(wgpu::TlasInstance::new(

--- a/src/lidar/mod.rs
+++ b/src/lidar/mod.rs
@@ -93,9 +93,7 @@ impl Lidar {
                 },
                 wgpu::BindGroupEntry {
                     binding: 1,
-                    resource: wgpu::BindingResource::AccelerationStructure(
-                        &scene.tlas_package,
-                    ),
+                    resource: wgpu::BindingResource::AccelerationStructure(&scene.tlas_package),
                 },
                 wgpu::BindGroupEntry {
                     binding: 2,
@@ -187,9 +185,7 @@ impl Lidar {
                 },
                 wgpu::BindGroupEntry {
                     binding: 1,
-                    resource: wgpu::BindingResource::AccelerationStructure(
-                        &scene.tlas_package,
-                    ),
+                    resource: wgpu::BindingResource::AccelerationStructure(&scene.tlas_package),
                 },
                 wgpu::BindGroupEntry {
                     binding: 2,

--- a/src/lidar/mod.rs
+++ b/src/lidar/mod.rs
@@ -135,7 +135,7 @@ impl Lidar {
         let (sender, receiver) = flume::bounded(1);
         buffer_slice.map_async(wgpu::MapMode::Read, move |v| sender.send(v).unwrap());
 
-        device.poll(wgpu::Maintain::wait()).panic_on_timeout();
+        device.poll(wgpu::PollType::wait()).unwrap();
 
         receiver.recv().unwrap().unwrap();
 
@@ -225,7 +225,7 @@ impl Lidar {
         let (sender, receiver) = flume::bounded(1);
         buffer_slice.map_async(wgpu::MapMode::Read, move |v| sender.send(v).unwrap());
 
-        device.poll(wgpu::Maintain::wait()).panic_on_timeout();
+        device.poll(wgpu::PollType::wait()).unwrap();
 
         receiver.recv().unwrap().unwrap();
 

--- a/src/lidar/mod.rs
+++ b/src/lidar/mod.rs
@@ -94,7 +94,7 @@ impl Lidar {
                 wgpu::BindGroupEntry {
                     binding: 1,
                     resource: wgpu::BindingResource::AccelerationStructure(
-                        &scene.tlas_package.tlas(),
+                        &scene.tlas_package,
                     ),
                 },
                 wgpu::BindGroupEntry {
@@ -184,7 +184,7 @@ impl Lidar {
                 wgpu::BindGroupEntry {
                     binding: 1,
                     resource: wgpu::BindingResource::AccelerationStructure(
-                        &scene.tlas_package.tlas(),
+                        &scene.tlas_package,
                     ),
                 },
                 wgpu::BindGroupEntry {

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -126,15 +126,13 @@ pub async fn get_raytracing_gpu(instance: &wgpu::Instance) -> (Adapter, Device, 
     .await;
 
     let Ok((device, queue)) = adapter
-        .request_device(
-            &wgpu::DeviceDescriptor {
-                label: None,
-                required_features,
-                required_limits: wgpu::Limits::downlevel_defaults(),
-                memory_hints: wgpu::MemoryHints::MemoryUsage,
-            },
-            None,
-        )
+        .request_device(&wgpu::DeviceDescriptor {
+            label: None,
+            required_features,
+            required_limits: wgpu::Limits::downlevel_defaults(),
+            memory_hints: wgpu::MemoryHints::MemoryUsage,
+            trace: wgpu::Trace::Off,
+        })
         .await
     else {
         panic!("Failed to create device");


### PR DESCRIPTION
Fixes #2 

The current API is based of an older arbitrary commit hash. This commit migrates the code to the latest version of wgpu in `trunk`. Specifically: [440b33f](https://github.com/gfx-rs/wgpu/commit/440b33f4c60dd5c014b7f6c9584c6736cd4e9158)