### PR TITLE
Pin to stable wgpu version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ bytemuck_derive = "1.8.0"
 flume = "0.11.1"
 glam = { version = "0.29.2", features = ["bytemuck"] }
 tokio = {version ="1.41.1",  features = ["full"]}
-wgpu = { git = "https://github.com/gfx-rs/wgpu", rev = "440b33f" }
+wgpu = "26.0.*"
 rerun = "0.22.0"
 rand = "0.9.0"
 


### PR DESCRIPTION
The Raytracing APIs are now part of WGPU 26. This PR makes sure the bump is made to WGPU 26.